### PR TITLE
Use correct ID when setting Photo.referencingReportID

### DIFF
--- a/o-fish-ios/Views/Components/AddAttachmentsButton.swift
+++ b/o-fish-ios/Views/Components/AddAttachmentsButton.swift
@@ -11,6 +11,7 @@ struct AddAttachmentsButton: View {
     @ObservedObject var attachments: AttachmentsViewModel
 
     @State private var popoverId = UUID().uuidString
+    let reportId: String
 
     var body: some View {
         Button(action: { self.showCustomActionSheet() }) {
@@ -20,7 +21,7 @@ struct AddAttachmentsButton: View {
 
     private func showPhotoTaker() {
         hidePopover()
-        PhotoCaptureController.show(reportID: self.attachments.id) { controller, photoId in
+        PhotoCaptureController.show(reportID: reportId) { controller, photoId in
             self.attachments.photoIDs.append(photoId)
             controller.hide()
         }
@@ -53,6 +54,6 @@ struct AddAttachmentsButton: View {
 
 struct AddAttachmentsButton_Previews: PreviewProvider {
     static var previews: some View {
-        AddAttachmentsButton(attachments: .sample)
+        AddAttachmentsButton(attachments: .sample, reportId: "TestID")
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Activity/ActivityItemView.swift
+++ b/o-fish-ios/Views/ReportFlow/Activity/ActivityItemView.swift
@@ -50,6 +50,7 @@ struct ActivityItemView: View {
     @Binding var name: String
     var showingWarningState: Bool
     var activityItem: ActivityItem
+    let reportId: String
 
     @State private var showingSheetItem: ActivityItem.SheetItem?
 
@@ -64,7 +65,7 @@ struct ActivityItemView: View {
                 VStack(spacing: Dimensions.spacing) {
                     HStack {
                         TitleLabel(title: title)
-                        AddAttachmentsButton(attachments: attachments)
+                        AddAttachmentsButton(attachments: attachments, reportId: reportId)
                     }
                         .padding(.top, Dimensions.spacing)
 
@@ -109,17 +110,20 @@ struct ActivityItemView_Previews: PreviewProvider {
             ActivityItemView(attachments: .sample,
                              name: .constant("Activity"),
                              showingWarningState: false,
-                             activityItem: .activity)
+                             activityItem: .activity,
+                             reportId: "TestId")
 
             ActivityItemView(attachments: .sample,
                                         name: .constant(""),
                                         showingWarningState: true,
-                                        activityItem: .fishery)
+                                        activityItem: .fishery,
+                                        reportId: "TestId")
 
             ActivityItemView(attachments: .sample,
                              name: .constant("Gear Type"),
                              showingWarningState: false,
-                             activityItem: .gear)
+                             activityItem: .gear,
+                             reportId: "TestId")
         }
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Activity/ActivityView.swift
+++ b/o-fish-ios/Views/ReportFlow/Activity/ActivityView.swift
@@ -16,6 +16,7 @@ enum ActivityItem: String {
 struct ActivityView: View {
 
     @ObservedObject private var inspection: InspectionViewModel
+    let reportId: String
     @Binding private var allFieldsComplete: Bool
     @Binding private var showingWarningState: Bool
 
@@ -26,10 +27,12 @@ struct ActivityView: View {
     private let spacing: CGFloat = 16
 
     init(inspection: InspectionViewModel,
+         reportId: String,
          allFieldsComplete: Binding<Bool>,
          showingWarningState: Binding<Bool>) {
 
         self.inspection = inspection
+        self.reportId = reportId
 
         _allFieldsComplete = allFieldsComplete
         _showingWarningState = showingWarningState
@@ -46,17 +49,20 @@ struct ActivityView: View {
                 ActivityItemView(attachments: self.inspection.activity.attachments,
                                  name: self.activityNameBinding,
                                  showingWarningState: self.showingActivityWarning,
-                                 activityItem: .activity)
+                                 activityItem: .activity,
+                                 reportId: self.reportId)
 
                 ActivityItemView(attachments: self.inspection.fishery.attachments,
                                  name: self.fisheryNameBinding,
                                  showingWarningState: self.showingFisheryWarning,
-                                 activityItem: .fishery)
+                                 activityItem: .fishery,
+                                 reportId: self.reportId)
 
                 ActivityItemView(attachments: self.inspection.gearType.attachments,
                                  name: self.gearNameBinding,
                                  showingWarningState: self.showingGearWarning,
-                                 activityItem: .gear)
+                                 activityItem: .gear,
+                                 reportId: self.reportId)
             }
         }
     }
@@ -103,7 +109,9 @@ struct ActivityView: View {
 
 struct ActivityView_Previews: PreviewProvider {
     static var previews: some View {
-        ActivityView(inspection: .sample,
+        ActivityView(
+            inspection: .sample,
+            reportId: "TestId",
             allFieldsComplete: .constant(false),
             showingWarningState: .constant(false))
     }

--- a/o-fish-ios/Views/ReportFlow/Catch/CatchInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Catch/CatchInputView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CatchInputView: View {
     @Binding var isCatchNonEmpty: Bool
     @ObservedObject var catchModel: CatchViewModel
+    let reportId: String
     let index: Int
     var removeClicked: ((CatchViewModel) -> Void)?
 
@@ -31,7 +32,7 @@ struct CatchInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: NSLocalizedString("Catch", comment: "") + " \(self.index)")
-                AddAttachmentsButton(attachments: catchModel.attachments)
+                AddAttachmentsButton(attachments: catchModel.attachments, reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -149,6 +150,6 @@ struct CatchInputView: View {
 
 struct CatchInputView_Previews: PreviewProvider {
     static var previews: some View {
-        CatchInputView(isCatchNonEmpty: .constant(true), catchModel: .sample, index: 1)
+        CatchInputView(isCatchNonEmpty: .constant(true), catchModel: .sample, reportId: "TestId", index: 1)
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Catch/CatchOnBoardView.swift
+++ b/o-fish-ios/Views/ReportFlow/Catch/CatchOnBoardView.swift
@@ -12,6 +12,7 @@ struct CatchOnBoardView: View {
     @Binding var isCatchNonEmpty: Bool
 
     @ObservedObject var catchModel: CatchViewModel
+    let reportId: String
     let index: Int
 
     var removeClicked: ((CatchViewModel) -> Void)?
@@ -19,8 +20,10 @@ struct CatchOnBoardView: View {
     var body: some View {
             wrappedShadowView {
                 if catchModel.id == currentEditingCatchId {
-                    CatchInputView(isCatchNonEmpty: self.$isCatchNonEmpty,
+                    CatchInputView(
+                        isCatchNonEmpty: self.$isCatchNonEmpty,
                         catchModel: catchModel,
+                        reportId: reportId,
                         index: index,
                         removeClicked: removeClicked)
                 } else {
@@ -39,14 +42,18 @@ struct CatchOnBoard_Previews: PreviewProvider {
 
     static var previews: some View {
         VStack {
-            CatchOnBoardView(currentEditingCatchId: .constant("1"),
+            CatchOnBoardView(
+                currentEditingCatchId: .constant("1"),
                 isCatchNonEmpty: .constant(false),
                 catchModel: .sample,
+                reportId: "TestId",
                 index: 1
             )
-            CatchOnBoardView(currentEditingCatchId: .constant(catchModel.id),
+            CatchOnBoardView(
+                currentEditingCatchId: .constant(catchModel.id),
                 isCatchNonEmpty: .constant(false),
                 catchModel: catchModel,
+                reportId: "TestId",
                 index: 1
             )
         }

--- a/o-fish-ios/Views/ReportFlow/Catch/CatchView.swift
+++ b/o-fish-ios/Views/ReportFlow/Catch/CatchView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CatchView: View {
     @ObservedObject private var inspection: InspectionViewModel
+    let reportId: String
 
     @State private var currentlyEditingCatchId: String
     @State private var showingAddCatchButton: Bool
@@ -22,6 +23,7 @@ struct CatchView: View {
     }
 
     init(inspection: InspectionViewModel,
+         reportId: String,
          allFieldsComplete: Binding<Bool>) {
 
         _currentlyEditingCatchId = State(initialValue: inspection.actualCatch.last?.id ?? "")
@@ -30,6 +32,7 @@ struct CatchView: View {
         _allFieldsComplete = allFieldsComplete
 
         self.inspection = inspection
+        self.reportId = reportId
     }
 
     var body: some View {
@@ -39,6 +42,7 @@ struct CatchView: View {
                     CatchOnBoardView(currentEditingCatchId: self.$currentlyEditingCatchId,
                         isCatchNonEmpty: self.$showingAddCatchButton,
                         catchModel: catchModel,
+                        reportId: self.reportId,
                         index: index + 1,
                         removeClicked: self.removeFishOnBoardClicked
                     )
@@ -82,7 +86,9 @@ struct CatchView: View {
 
 struct CatchView_Previews: PreviewProvider {
     static var previews: some View {
-        CatchView(inspection: .sample,
+        CatchView(
+            inspection: .sample,
+            reportId: "TestId",
             allFieldsComplete: .constant(false))
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Crew/CrewMemberInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Crew/CrewMemberInputView.swift
@@ -13,6 +13,7 @@ struct CrewMemberInputView: View {
     @Binding private var showingWarningState: Bool
 
     @ObservedObject private var crewMember: CrewMemberViewModel
+    let reportId: String
 
     private var index: Int = 0
     private var isCaptain: Bool = false
@@ -31,6 +32,7 @@ struct CrewMemberInputView: View {
          informationComplete: Binding<Bool>,
          showingWarningState: Binding<Bool>,
          crewMember: CrewMemberViewModel,
+         reportId: String,
          index: Int = 0,
          isCaptain: Bool = false,
          removeClicked: ((CrewMemberViewModel) -> Void)? = nil) {
@@ -40,6 +42,7 @@ struct CrewMemberInputView: View {
         _showingWarningState = showingWarningState
 
         self.crewMember = crewMember
+        self.reportId = reportId
         self.index = index
         self.isCaptain = isCaptain
         self.removeClicked = removeClicked
@@ -52,7 +55,7 @@ struct CrewMemberInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: isCaptain ? "Captain" : "Crew Member \(index)")
-                AddAttachmentsButton(attachments: crewMember.attachments)
+                AddAttachmentsButton(attachments: crewMember.attachments, reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -108,18 +111,21 @@ struct CrewMemberInputView_Previews: PreviewProvider {
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false),
                 crewMember: .sample,
+                reportId: "TestID",
                 isCaptain: true)
 
             CrewMemberInputView(isCrewMemberNonEmpty: .constant(true),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false),
                 crewMember: .sample,
+                reportId: "TestID",
                 isCaptain: false)
 
             CrewMemberInputView(isCrewMemberNonEmpty: .constant(true),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(true),
                 crewMember: .sample,
+                reportId: "TestID",
                 isCaptain: false)
         }
     }

--- a/o-fish-ios/Views/ReportFlow/Crew/CrewMemberView.swift
+++ b/o-fish-ios/Views/ReportFlow/Crew/CrewMemberView.swift
@@ -14,6 +14,7 @@ struct CrewMemberView: View {
     @Binding var showingWarningState: Bool
 
     @ObservedObject var crewMember: CrewMemberViewModel
+    let reportId: String
 
     var index: Int = 0
 
@@ -27,6 +28,7 @@ struct CrewMemberView: View {
                     informationComplete: $informationComplete,
                     showingWarningState: $showingWarningState,
                     crewMember: crewMember,
+                    reportId: reportId,
                     index: index,
                     isCaptain: crewMember.isCaptain,
                     removeClicked: removeClicked)
@@ -50,6 +52,7 @@ struct CrewMemberView_Previews: PreviewProvider {
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false),
                 crewMember: .sample,
+                reportId: "TestId",
                 index: 1
             )
             CrewMemberView(currentEditingCrewMemberId: .constant(crewMember.id),
@@ -57,6 +60,7 @@ struct CrewMemberView_Previews: PreviewProvider {
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false),
                 crewMember: crewMember,
+                reportId: "TestId",
                 index: 1
             )
         }

--- a/o-fish-ios/Views/ReportFlow/Crew/CrewView.swift
+++ b/o-fish-ios/Views/ReportFlow/Crew/CrewView.swift
@@ -66,6 +66,7 @@ struct CrewView: View {
                                 }),
 
                         crewMember: member,
+                        reportId: self.report.id,
                         index: index + 1,
                         editClicked: self.editItemClicked,
                         removeClicked: self.removeItemClicked

--- a/o-fish-ios/Views/ReportFlow/Risk/RiskView.swift
+++ b/o-fish-ios/Views/ReportFlow/Risk/RiskView.swift
@@ -25,7 +25,7 @@ struct RiskView: View {
                     HStack {
                         TitleLabel(title: "Risk")
                         Spacer()
-                        AddAttachmentsButton(attachments: self.report.inspection.attachments)
+                        AddAttachmentsButton(attachments: self.report.inspection.attachments, reportId: self.report.id)
                     }
                         .padding(.top, Dimensions.spacing)
 
@@ -46,7 +46,8 @@ struct RiskView: View {
 
 struct RiskView_Previews: PreviewProvider {
     static var previews: some View {
-        RiskView(report: .sample,
+        RiskView(
+            report: .sample,
             allFieldsComplete: .constant(false))
     }
 }

--- a/o-fish-ios/Views/ReportFlow/TopTabBarContainerView.swift
+++ b/o-fish-ios/Views/ReportFlow/TopTabBarContainerView.swift
@@ -107,17 +107,23 @@ struct TopTabBarContainerView: View {
                 BasicInfoView(report: self.report, allFieldsComplete: allFieldsCompleteBinding)
 
             } else if self.isVesselSelected {
-                VesselView(vessel: report.vessel,
+                VesselView(
+                    vessel: report.vessel,
+                    reportId: report.id,
                     prefilledVesselAvailable: $prefilledVesselAvailable,
                     allFieldsComplete: allFieldsCompleteBinding,
                     showingWarningState: $showingNotCompleteState)
 
             } else if self.isWhatsOnBoardSelected {
-                CatchView(inspection: report.inspection,
+                CatchView(
+                    inspection: report.inspection,
+                    reportId: report.id,
                     allFieldsComplete: allFieldsCompleteBinding)
 
             } else if self.isActivitySelected {
-                ActivityView(inspection: report.inspection,
+                ActivityView(
+                    inspection: report.inspection,
+                    reportId: report.id,
                     allFieldsComplete: allFieldsCompleteBinding,
                     showingWarningState: $showingNotCompleteState)
 

--- a/o-fish-ios/Views/ReportFlow/Vessel/DeliveryInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/DeliveryInputView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DeliveryInputView: View {
     @ObservedObject var delivery: DeliveryViewModel
+    let reportId: String
     @Binding var activeEditableComponentId: String
     @Binding var informationComplete: Bool
     @Binding var showingWarningState: Bool
@@ -27,11 +28,13 @@ struct DeliveryInputView: View {
     }
 
     init(delivery: DeliveryViewModel,
+         reportId: String,
          activeEditableComponentId: Binding<String>,
          informationComplete: Binding<Bool>,
          showingWarningState: Binding<Bool>) {
 
         self.delivery = delivery
+        self.reportId = reportId
         _activeEditableComponentId = activeEditableComponentId
         _informationComplete = informationComplete
         _showingWarningState = showingWarningState
@@ -45,7 +48,9 @@ struct DeliveryInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: "Last Delivery")
-                AddAttachmentsButton(attachments: delivery.attachments)
+                AddAttachmentsButton(
+                    attachments: delivery.attachments,
+                    reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -150,7 +155,9 @@ struct DeliveryInputView: View {
 
 struct DeliveryInputView_Previews: PreviewProvider {
     static var previews: some View {
-        DeliveryInputView(delivery: .sample,
+        DeliveryInputView(
+            delivery: .sample,
+            reportId: "TestId",
             activeEditableComponentId: .constant(""),
             informationComplete: .constant(false),
             showingWarningState: .constant(false))

--- a/o-fish-ios/Views/ReportFlow/Vessel/DeliveryView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/DeliveryView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct DeliveryView: View {
 
     @ObservedObject var delivery: DeliveryViewModel
+    let reportId: String
     @Binding var activeEditableComponentId: String
     @Binding var informationComplete: Bool
     @Binding var showingWarningState: Bool
@@ -18,7 +19,9 @@ struct DeliveryView: View {
         wrappedShadowView {
             VStack {
                 if activeEditableComponentId == delivery.id || delivery.isEmtpy {
-                    DeliveryInputView(delivery: delivery,
+                    DeliveryInputView(
+                        delivery: delivery,
+                        reportId: reportId,
                         activeEditableComponentId: $activeEditableComponentId,
                         informationComplete: $informationComplete,
                         showingWarningState: $showingWarningState)
@@ -35,14 +38,18 @@ struct DeliveryView: View {
 struct DeliveryView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            DeliveryView(delivery: .sample,
+            DeliveryView(
+                delivery: .sample,
+                reportId: "TestId",
                 activeEditableComponentId: .constant(""),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false))
 
             Divider()
 
-            DeliveryView(delivery: .sample,
+            DeliveryView(
+                delivery: .sample,
+                reportId: "TestId",
                 activeEditableComponentId: .constant("123"),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false))

--- a/o-fish-ios/Views/ReportFlow/Vessel/EMSInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/EMSInputView.swift
@@ -11,6 +11,7 @@ struct EMSInputView: View {
     @ObservedObject var ems: EMSViewModel
     @Binding var activeEditableComponentId: String
     @Binding var isEmsNonEmpty: Bool
+    let reportId: String
 
     var deleteClicked: ((String) -> Void)?
 
@@ -26,7 +27,7 @@ struct EMSInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: "Electronic Monitoring System")
-                AddAttachmentsButton(attachments: ems.attachments)
+                AddAttachmentsButton(attachments: ems.attachments, reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -83,7 +84,8 @@ struct EMSInputView_Previews: PreviewProvider {
         VStack {
             EMSInputView(ems: EMSViewModel.sample,
                          activeEditableComponentId: .constant("123"),
-                         isEmsNonEmpty: .constant(true))
+                         isEmsNonEmpty: .constant(true),
+                         reportId: "TestID")
         }
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Vessel/EMSView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/EMSView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EMSView: View {
     @ObservedObject var ems: EMSViewModel
+    let reportId: String
 
     @Binding var activeEditableComponentId: String
     @Binding var isEmsNonEmpty: Bool
@@ -20,6 +21,7 @@ struct EMSView: View {
                 EMSInputView(ems: ems,
                              activeEditableComponentId: $activeEditableComponentId,
                              isEmsNonEmpty: $isEmsNonEmpty,
+                             reportId: reportId,
                              deleteClicked: deleteClicked)
             } else {
                 EMSSummaryView(ems: ems, isEditable: true) {
@@ -34,11 +36,13 @@ struct EMSView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             EMSView(ems: .sample,
+                    reportId: "TestId",
                     activeEditableComponentId: .constant("123"),
                     isEmsNonEmpty: .constant(true),
                     deleteClicked: nil)
             Divider()
             EMSView(ems: .sample,
+                    reportId: "TestId",
                     activeEditableComponentId: .constant(""),
                     isEmsNonEmpty: .constant(true),
                     deleteClicked: nil)

--- a/o-fish-ios/Views/ReportFlow/Vessel/VesselInformationInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/VesselInformationInputView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct VesselInformationInputView: View {
     @ObservedObject var vessel: BoatViewModel
+    let reportId: String
     @Binding var activeEditableComponentId: String
     @Binding var informationComplete: Bool
     @Binding var showingWarningState: Bool
@@ -27,11 +28,13 @@ struct VesselInformationInputView: View {
     }
 
     init(vessel: BoatViewModel,
+         reportId: String,
          activeEditableComponentId: Binding<String>,
          informationComplete: Binding<Bool>,
          showingWarningState: Binding<Bool>) {
 
         self.vessel = vessel
+        self.reportId = reportId
         _activeEditableComponentId = activeEditableComponentId
         _informationComplete = informationComplete
         _showingWarningState = showingWarningState
@@ -46,7 +49,7 @@ struct VesselInformationInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack(alignment: .center) {
                 TitleLabel(title: "Vessel Information")
-                AddAttachmentsButton(attachments: vessel.attachments)
+                AddAttachmentsButton(attachments: vessel.attachments, reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -142,13 +145,17 @@ struct VesselInformationInputView: View {
 struct VesselInformationInputView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            VesselInformationInputView(vessel: .sample,
+            VesselInformationInputView(
+                vessel: .sample,
+                reportId: "TestId",
                 activeEditableComponentId: .constant(""),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false))
             .environment(\.locale, .init(identifier: "uk"))
 
-            VesselInformationInputView(vessel: .sample,
+            VesselInformationInputView(
+                vessel: .sample,
+                reportId: "TestId",
                 activeEditableComponentId: .constant(""),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(true))

--- a/o-fish-ios/Views/ReportFlow/Vessel/VesselInformationView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/VesselInformationView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct VesselInformationView: View {
 
     @ObservedObject var vessel: BoatViewModel
+    let reportId: String
     @Binding var activeEditableComponentId: String
     @Binding var informationComplete: Bool
     @Binding var showingWarningState: Bool
@@ -17,7 +18,9 @@ struct VesselInformationView: View {
     var body: some View {
         wrappedShadowView {
             if activeEditableComponentId == vessel.id || vessel.isEmpty {
-                VesselInformationInputView(vessel: vessel,
+                VesselInformationInputView(
+                    vessel: vessel,
+                    reportId: reportId,
                     activeEditableComponentId: $activeEditableComponentId,
                     informationComplete: $informationComplete,
                     showingWarningState: $showingWarningState)
@@ -34,12 +37,16 @@ struct VesselInformationView: View {
 struct VesselInformationView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            VesselInformationView(vessel: .sample,
+            VesselInformationView(
+                vessel: .sample,
+                reportId: "TestId",
                 activeEditableComponentId: .constant(""),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false))
             Divider()
-            VesselInformationView(vessel: .sample,
+            VesselInformationView(
+                vessel: .sample,
+                reportId: "TestId",
                 activeEditableComponentId: .constant("123"),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false))

--- a/o-fish-ios/Views/ReportFlow/Vessel/VesselView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/VesselView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct VesselView: View {
     @ObservedObject var vessel: BoatViewModel
+    let reportId: String
 
     @State private var activeEditableComponentId: String
     @State private var showingAddEMSButton: Bool
@@ -23,11 +24,13 @@ struct VesselView: View {
     @Binding private var showingWarningState: Bool
 
     init(vessel: BoatViewModel,
+         reportId: String,
          prefilledVesselAvailable: Binding<Bool>,
          allFieldsComplete: Binding<Bool>,
          showingWarningState: Binding<Bool>) {
 
         self.vessel = vessel
+        self.reportId = reportId
         _activeEditableComponentId = State(initialValue: vessel.id)
         _showingAddEMSButton = State(initialValue: vessel.ems.filter({ $0.isEmpty }).isEmpty)
         _showingPrefilledAlert = prefilledVesselAvailable
@@ -48,7 +51,9 @@ struct VesselView: View {
         KeyboardControllingScrollView {
             Group {
                 VStack(spacing: Dimensions.itemsSpacing) {
-                    VesselInformationView(vessel: self.vessel,
+                    VesselInformationView(
+                        vessel: self.vessel,
+                        reportId: self.reportId,
                         activeEditableComponentId: self.$activeEditableComponentId,
                         informationComplete:
                             Binding<Bool>(get: { self.informationComplete },
@@ -58,7 +63,9 @@ struct VesselView: View {
                                 }),
                         showingWarningState: self.$showingWarningState)
 
-                    DeliveryView(delivery: self.vessel.lastDelivery,
+                    DeliveryView(
+                        delivery: self.vessel.lastDelivery,
+                        reportId: self.reportId,
                         activeEditableComponentId: self.$activeEditableComponentId,
                         informationComplete:
                             Binding<Bool>(get: { self.deliveryComplete },
@@ -70,7 +77,9 @@ struct VesselView: View {
 
                     VStack(spacing: Dimensions.itemsSpacing) {
                         ForEach(self.vessel.ems) { ems in
-                            EMSView(ems: ems,
+                            EMSView(
+                                ems: ems,
+                                reportId: self.reportId,
                                 activeEditableComponentId: self.$activeEditableComponentId,
                                 isEmsNonEmpty: self.$showingAddEMSButton,
                                 deleteClicked: self.emsDeleteClicked)
@@ -146,9 +155,11 @@ struct VesselView: View {
 
 struct VesselView_Previews: PreviewProvider {
     static var previews: some View {
-        VesselView(vessel: .sample,
-                   prefilledVesselAvailable: .constant(true),
-                   allFieldsComplete: .constant(false),
-                   showingWarningState: .constant(false))
+        VesselView(
+            vessel: .sample,
+            reportId: "TestId",
+            prefilledVesselAvailable: .constant(true),
+            allFieldsComplete: .constant(false),
+            showingWarningState: .constant(false))
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Violations/ViolationCreateCrewMemberView.swift
+++ b/o-fish-ios/Views/ReportFlow/Violations/ViolationCreateCrewMemberView.swift
@@ -39,7 +39,9 @@ struct ViolationCreateCrewMemberView: View {
                 VStack(spacing: Dimensions.spacing) {
                     HStack {
                         TitleLabel(title: "Crew Member")
-                        AddAttachmentsButton(attachments: attachments)
+                        AddAttachmentsButton(
+                            attachments: attachments,
+                            reportId: report.id)
                     }
                         .padding(.vertical, Dimensions.spacing)
 

--- a/o-fish-ios/Views/ReportFlow/Violations/ViolationInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Violations/ViolationInputView.swift
@@ -33,7 +33,9 @@ struct ViolationInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: NSLocalizedString("Violation", comment: "") + " \(index)")
-                AddAttachmentsButton(attachments: violation.attachments)
+                AddAttachmentsButton(
+                    attachments: violation.attachments,
+                    reportId: report.id)
             }
                 .padding(.top, Dimensions.spacing)
 

--- a/o-fish-ios/Views/ReportFlow/Violations/ViolationSeizureInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Violations/ViolationSeizureInputView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ViolationSeizureInputView: View {
     @ObservedObject var seizure: SeizuresViewModel
+    let reportId: String
 
     private enum Dimensions {
         static let spacing: CGFloat = 16
@@ -20,7 +21,7 @@ struct ViolationSeizureInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: "Seizure")
-                AddAttachmentsButton(attachments: seizure.attachments)
+                AddAttachmentsButton(attachments: seizure.attachments, reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -38,6 +39,6 @@ struct ViolationSeizureInputView: View {
 
 struct ViolationSeizureInputView_Previews: PreviewProvider {
     static var previews: some View {
-        ViolationSeizureInputView(seizure: .sample)
+        ViolationSeizureInputView(seizure: .sample, reportId: "testID")
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Violations/ViolationsView.swift
+++ b/o-fish-ios/Views/ReportFlow/Violations/ViolationsView.swift
@@ -65,7 +65,7 @@ struct ViolationsView: View {
                 }
 
                 wrappedShadowView {
-                    ViolationSeizureInputView(seizure: self.summary.seizures)
+                    ViolationSeizureInputView(seizure: self.summary.seizures, reportId: self.report.id)
                 }
 
                 // TODO: Should be revisited after the June 2020 SwiftUI improvements


### PR DESCRIPTION
[-] Pass the `id` of the new Report's view model down through the view hierarchy
[-] Use the Report id to set Photo.referencingReportID for all Photo Objects being added to this Report

fixes #116 