### PR TITLE
Syncuser realm access

### DIFF
--- a/o-fish-ios/Model/Settings.swift
+++ b/o-fish-ios/Model/Settings.swift
@@ -13,10 +13,8 @@ let app = App(id: Constants.realmAppId)
 class Settings: ObservableObject {
     static let shared = Settings()
 
-    private init() {
-    }
-
-    var menuData = MenuData()
+    @Published var realmUser: RealmSwift.User?
+    @Published var menuData = MenuData()
 
     var intialZoomLevel = 322000 // Meters to show in map views, ~= 200 mi
 

--- a/o-fish-ios/Views/LoginView.swift
+++ b/o-fish-ios/Views/LoginView.swift
@@ -8,9 +8,7 @@
 import SwiftUI
 
 struct LoginView: View {
-    @Environment(\.presentationMode) var presentationMode
-
-    var loggedIn: Binding<Bool>
+    @EnvironmentObject var settings: Settings
 
     @State private var username = ""
     @State private var password = ""
@@ -118,9 +116,9 @@ struct LoginView: View {
             if let error = self.keychain.addCredentials(Credentials(username: username, password: password)) as? KeychainError {
                 print(error.localizedDescription)
             }
-
-            self.loggedIn.wrappedValue = true
-            self.presentationMode.wrappedValue.dismiss()
+            DispatchQueue.main.async {
+                self.settings.realmUser = user
+            }
         }
     }
 
@@ -138,9 +136,11 @@ struct LoginView: View {
 }
 
 struct LoginView_Previews: PreviewProvider {
+    static var settings = Settings()
+
     static var previews: some View {
         NavigationView {
-            LoginView(loggedIn: .constant(true))
+            LoginView().environmentObject(settings)
         }
     }
 }

--- a/o-fish-ios/Views/MainNavigationRootView.swift
+++ b/o-fish-ios/Views/MainNavigationRootView.swift
@@ -10,21 +10,27 @@ import SwiftUI
 // Only MainNavigationRootView should include a NavigationView, that NavigationView
 // will embed all of the other views
 struct MainNavigationRootView: View {
-    @State private var isLoggedIn = (app.currentUser()?.state == .loggedIn)
+    @EnvironmentObject var settings: Settings
 
     var body: some View {
-        NavigationView {
-            if isLoggedIn {
-                PatrolBoatView(isLoggedIn: $isLoggedIn)
+        if settings.realmUser == nil && app.currentUser()?.state == .loggedIn {
+            print("Using same user as when last running the app")
+            settings.realmUser = app.currentUser()
+        }
+        return NavigationView {
+            if settings.realmUser != nil {
+                PatrolBoatView()
             } else {
-                LoginView(loggedIn: self.$isLoggedIn)
+                LoginView()
             }
         }
     }
 }
 
 struct MainNavigationRootView_Previews: PreviewProvider {
+    static var settings = Settings()
     static var previews: some View {
         MainNavigationRootView()
+            .environmentObject(settings)
     }
 }

--- a/o-fish-ios/Views/PatrolBoat/DutyState.swift
+++ b/o-fish-ios/Views/PatrolBoat/DutyState.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-//import RealmSwift
 
 class DutyState: ObservableObject {
 

--- a/o-fish-ios/Views/PatrolBoat/DutyState.swift
+++ b/o-fish-ios/Views/PatrolBoat/DutyState.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import RealmSwift
+//import RealmSwift
 
 class DutyState: ObservableObject {
 

--- a/o-fish-ios/Views/PatrolBoat/PatrolBoatView.swift
+++ b/o-fish-ios/Views/PatrolBoat/PatrolBoatView.swift
@@ -149,7 +149,6 @@ struct PatrolBoatView: View {
 
     private func showOptionsModal() {
         guard let user = settings.realmUser else {
-//            self.isLoggedIn.wrappedValue = false
             print("realmUser not set")
             return
         }
@@ -225,7 +224,6 @@ struct PatrolBoatView: View {
 
     private func onAppear() {
         guard let user = settings.realmUser else {
-//            self.isLoggedIn.wrappedValue = false
             print("realmUser not set")
             return
         }
@@ -253,7 +251,6 @@ struct PatrolBoatView: View {
             DispatchQueue.main.async {
                 self.settings.realmUser = nil
             }
-//            self.isLoggedIn.wrappedValue = false
             NotificationManager.shared.removeAllNotification()
         }
     }

--- a/o-fish-ios/Views/PreboardingFlow/PreboardingView/PreboardingView.swift
+++ b/o-fish-ios/Views/PreboardingFlow/PreboardingView/PreboardingView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 enum ViewType {
     case searchRecords
@@ -16,6 +15,7 @@ enum ViewType {
 struct PreboardingView: View {
 
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var settings: Settings
 
     var viewType: ViewType = .preboarding
     @ObservedObject var onDuty: DutyState
@@ -92,7 +92,7 @@ struct PreboardingView: View {
                         self.searchDebouncer.call()
 
                     } else {
-                        self.storedReports = []
+                        self.storedReports.removeAll(keepingCapacity: true)
                         self.state = .loaded
                     }
                 }),
@@ -152,10 +152,10 @@ struct PreboardingView: View {
     }
 
     private func loadReports(with searchText: String) {
-        storedReports = []
+        storedReports.removeAll(keepingCapacity: true)
         showingRecentBoardings = false
         let predicate = NSPredicate(format: "vessel.name CONTAINS[cd] %@", searchText)
-        let realmReports = app.currentUser()?
+        let realmReports = settings.realmUser?
             .agencyRealm()?
             .objects(Report.self)
             .filter(predicate)
@@ -175,23 +175,22 @@ struct PreboardingView: View {
     }
 
     private func loadRecentBoardings() {
-        if storedReports.isEmpty {
-            let realmReports = app.currentUser()?
-                .agencyRealm()?
-                .objects(Report.self)
-                .sorted(byKeyPath: "timestamp", ascending: false) ?? nil
-            var uniqueIdentifiers = [String]()
-            if let realmReports = realmReports {
-                for report in realmReports {
-                    if let vessel = report.vessel {
-                        if uniqueIdentifiers.filter({$0 == vessel.permitNumber || $0 == vessel.name }).isEmpty &&
-                            !vessel.name.isEmpty {
-                            uniqueIdentifiers.append(vessel.permitNumber.isEmpty ? vessel.name : vessel.permitNumber)
-                            storedReports.append(ReportViewModel(report))
-                            if storedReports.count > countOfRecentReportsShown - 1 {
-                                self.state = .loaded
-                                return
-                            }
+        let realmReports = settings.realmUser?
+            .agencyRealm()?
+            .objects(Report.self)
+            .sorted(byKeyPath: "timestamp", ascending: false) ?? nil
+        var uniqueIdentifiers = [String]()
+        storedReports.removeAll(keepingCapacity: true)
+        if let realmReports = realmReports {
+            for report in realmReports {
+                if let vessel = report.vessel {
+                    if uniqueIdentifiers.filter({$0 == vessel.permitNumber || $0 == vessel.name }).isEmpty &&
+                        !vessel.name.isEmpty {
+                        uniqueIdentifiers.append(vessel.permitNumber.isEmpty ? vessel.name : vessel.permitNumber)
+                        storedReports.append(ReportViewModel(report))
+                        if storedReports.count > countOfRecentReportsShown - 1 {
+                            self.state = .loaded
+                            return
                         }
                     }
                 }
@@ -202,15 +201,18 @@ struct PreboardingView: View {
 }
 
 struct PreboardingView_Previews: PreviewProvider {
+    static var settings = Settings()
     static var previews: some View {
         VStack {
             PreboardingView(viewType: .preboarding,
                             onDuty: .sample,
                             rootIsActive: .constant(true))
+                .environmentObject(settings)
             Divider()
             PreboardingView(viewType: .searchRecords,
                             onDuty: .sample,
                             rootIsActive: .constant(true))
+                .environmentObject(settings)
         }
     }
 }

--- a/o-fish-ios/Views/PreboardingFlow/VesselRecordView/LoadingVesselRecordView.swift
+++ b/o-fish-ios/Views/PreboardingFlow/VesselRecordView/LoadingVesselRecordView.swift
@@ -6,11 +6,11 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 struct LoadingVesselRecordView: View {
 
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var settings: Settings
     @ObservedObject var report: ReportViewModel
     @ObservedObject var onDuty: DutyState
     @Binding var rootIsActive: Bool
@@ -40,7 +40,7 @@ struct LoadingVesselRecordView: View {
     private func loadReports() {
         storedReports = []
         let predicate = NSPredicate(format: "vessel.name == %@ AND vessel.permitNumber == %@", report.vessel.name, report.vessel.permitNumber)
-        let realmReports = app.currentUser()?
+        let realmReports = settings.realmUser?
             .agencyRealm()?
             .objects(Report.self)
             .filter(predicate)
@@ -55,9 +55,11 @@ struct LoadingVesselRecordView: View {
 }
 
 struct LoadingVesselRecordView_Previews: PreviewProvider {
+    static var settings = Settings()
     static var previews: some View {
         LoadingVesselRecordView(report: .sample,
                                 onDuty: .sample,
                                 rootIsActive: .constant(true))
+        .environmentObject(settings)
     }
 }

--- a/o-fish-ios/Views/ReportFlow/ChooseScreens/ChooseBusiness/ChooseBusinessView.swift
+++ b/o-fish-ios/Views/ReportFlow/ChooseScreens/ChooseBusiness/ChooseBusinessView.swift
@@ -14,6 +14,7 @@ struct ChooseBusinessView: View {
     @Binding var isAutofillItem: Bool
     @State private var searchText = ""
     @Environment(\.presentationMode) private var presentationMode
+    @EnvironmentObject var settings: Settings
 
     @State private var state: States<BusinessPickerData> = .loaded([])
     @State private var notificationTokenSearch: NotificationToken?
@@ -120,7 +121,7 @@ struct ChooseBusinessView: View {
     /// Logic
 
     private func loadFilteredData(searchText: String) {
-        let realmFilteredReports = app.currentUser()?.agencyRealm()?.objects(Report.self)
+        let realmFilteredReports = settings.realmUser?.agencyRealm()?.objects(Report.self)
         var result = realmFilteredReports
 
         if searchText != "" {
@@ -196,15 +197,15 @@ struct ChooseBusinessView: View {
         }
 
         unique.removeAll { $0.business.isEmpty && $0.location.isEmpty }
-
         return unique
     }
 }
 
 struct ChooseBusinessView_Previews: PreviewProvider {
+    static var settings = Settings()
     static var previews: some View {
         let selectedItem = BusinessPickerData(business: "P. Sherman", location: "Location")
         return ChooseBusinessView(selectedItem: .constant(selectedItem),
-            isAutofillItem: .constant(true))
+            isAutofillItem: .constant(true)).environmentObject(settings)
     }
 }

--- a/o-fish-ios/Views/ReportFlow/ReportNavigationRootView.swift
+++ b/o-fish-ios/Views/ReportFlow/ReportNavigationRootView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ReportNavigationRootView: View {
     @Environment(\.presentationMode) var presentationMode
-
     @ObservedObject var report: ReportViewModel
     @Binding var rootIsActive: Bool
 


### PR DESCRIPTION
Store Realm `User` as an `EnvironmentObject` (within `Settings`)
[x] Add `realUser` to `Settings` class
[x] Add `Settings` as an environment object
[x] Use `realmUser` from the views
[x] Remove the `loggedIn` state

fixes #253 
fixes #235 