### PR TITLE
No photos or notes

### DIFF
--- a/o-fish-ios/ViewModel/Report/AttachmentsViewModel.swift
+++ b/o-fish-ios/ViewModel/Report/AttachmentsViewModel.swift
@@ -46,22 +46,24 @@ class AttachmentsViewModel: ObservableObject, Identifiable {
         })
         return attachments
     }
-
-    func clone() -> AttachmentsViewModel {
+    
+    func clone(withoutNotes: Bool = true) -> AttachmentsViewModel {
         let clone = AttachmentsViewModel()
-
+        
         if let photoIDs = attachments?.photoIDs {
             for index in photoIDs.indices {
                 clone.photoIDs.append(photoIDs[index])
             }
         }
-
-        if let notes = attachments?.notes {
-            for index in notes.indices {
-                clone.notes.append(Note(text: notes[index]))
+        
+        if !withoutNotes {
+            if let notes = attachments?.notes {
+                for index in notes.indices {
+                    clone.notes.append(Note(text: notes[index]))
+                }
             }
         }
-
+        
         return clone
     }
 }

--- a/o-fish-ios/ViewModel/Report/CrewMemberViewModel.swift
+++ b/o-fish-ios/ViewModel/Report/CrewMemberViewModel.swift
@@ -54,11 +54,11 @@ class CrewMemberViewModel: ObservableObject, Identifiable {
         return crewMember
     }
 
-    func clone() -> CrewMemberViewModel {
+    func clone(wihtoutNotes: Bool = true) -> CrewMemberViewModel {
         let clone = CrewMemberViewModel()
         clone.name = crewMember?.name ?? ""
         clone.license = crewMember?.license ?? ""
-        clone.attachments = attachments.clone()
+        clone.attachments = attachments.clone(withoutNotes: wihtoutNotes)
 
         return clone
     }

--- a/o-fish-ios/Views/ReportDetails/RiskSummaryView.swift
+++ b/o-fish-ios/Views/ReportDetails/RiskSummaryView.swift
@@ -42,10 +42,12 @@ struct RiskSummaryView: View {
             if !risk.attachments.notes.isEmpty || !risk.attachments.photoIDs.isEmpty {
                 AttachmentsView(attachments: risk.attachments, isEditable: false)
             } else {
-                Text("No Notes or Photos for Risk")
-                    .font(.body)
-                    .foregroundColor(.captainGray)
-                    .padding(.vertical, Dimensions.verticalPadding)
+                if risk.reason.isEmpty {
+                    Text("No Notes or Photos for Risk")
+                        .font(.body)
+                        .foregroundColor(.captainGray)
+                        .padding(.vertical, Dimensions.verticalPadding)
+                }
             }
         }
         .padding(.vertical, Dimensions.spacing)

--- a/o-fish-ios/Views/ReportFlow/ReportNavigationRootView.swift
+++ b/o-fish-ios/Views/ReportFlow/ReportNavigationRootView.swift
@@ -27,7 +27,7 @@ struct ReportNavigationRootView: View {
         } else {
             print("Failed to read menus")
         }
-        _prefilledCrewAvailable = State(initialValue: prefilledAvailable)
+        _prefilledCrewAvailable = State(initialValue: !(report?.crew.isEmpty ?? true) || !(report?.captain.isEmpty ?? true))
     }
 
     var body: some View {


### PR DESCRIPTION
[-] Fixed Don't offer to prefill crew if previous report didn't include any crew
[-] Fixed title "No photos or notes" when amber exist.
[-] Fixed Do not bring over notes for vessel information
[-] Fixed Do not bring over notes for crew information
Fixes #271, #272, #273, #277