### PR TITLE
Store country code in Vessel Information page

### DIFF
--- a/o-fish-ios.xcodeproj/project.pbxproj
+++ b/o-fish-ios.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		BCE480EEF0B2F0E6A189ECC6 /* ViolationPickerDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48E834DC859834E1E01E4 /* ViolationPickerDataView.swift */; };
 		BCE4814543022D42A642CA4A /* KeyboardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE486CABA40FF0D6D14E5F9 /* KeyboardController.swift */; };
 		BCE4815F88C024AD476B8DE2 /* DutyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48D936613848423BBAF33 /* DutyState.swift */; };
-		BCE4817B0B89F5D95768925A /* CountryPickerView.swif.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE486BCBC428C8539A22A9D /* CountryPickerView.swif.swift */; };
+		BCE4817B0B89F5D95768925A /* CountryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE486BCBC428C8539A22A9D /* CountryPickerView.swift */; };
 		BCE4820A7E5A15B8AA93DB4A /* TextPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48555D654177BE1259C7B /* TextPickerView.swift */; };
 		BCE4825F4A971D6F6F24D571 /* CatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48E5B87FCD1126A5C26C4 /* CatchView.swift */; };
 		BCE48275C134A902EF0293D4 /* GlassIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48B8D8932DF568200B811 /* GlassIconView.swift */; };
@@ -525,7 +525,7 @@
 		BCE4867F873ECC8BEEF0AF47 /* ViolationCrewMemberSelectView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViolationCrewMemberSelectView.swift; sourceTree = "<group>"; };
 		BCE4869550ED589453572C7E /* VesselInformationInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VesselInformationInputView.swift; sourceTree = "<group>"; };
 		BCE486BBFA7E770F010DA1AA /* AlertItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertItem.swift; sourceTree = "<group>"; };
-		BCE486BCBC428C8539A22A9D /* CountryPickerView.swif.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryPickerView.swif.swift; sourceTree = "<group>"; };
+		BCE486BCBC428C8539A22A9D /* CountryPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryPickerView.swift; sourceTree = "<group>"; };
 		BCE486CABA40FF0D6D14E5F9 /* KeyboardController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardController.swift; sourceTree = "<group>"; };
 		BCE486E471A682C466E106D0 /* ModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalView.swift; sourceTree = "<group>"; };
 		BCE486EF5A22D91EE1260968 /* MainNavigationRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainNavigationRootView.swift; sourceTree = "<group>"; };
@@ -1229,7 +1229,7 @@
 		BCE48B04A5E3CDA8E4879663 /* Country */ = {
 			isa = PBXGroup;
 			children = (
-				BCE486BCBC428C8539A22A9D /* CountryPickerView.swif.swift */,
+				BCE486BCBC428C8539A22A9D /* CountryPickerView.swift */,
 				BCE4824D90AA3E6903C93562 /* CountryPickerDataView.swift */,
 			);
 			path = Country;
@@ -1731,7 +1731,7 @@
 				BCE48B9CAD5B8F1EB27C60BD /* ChooseEMSView.swift in Sources */,
 				BCE48B02D6D3331545500562 /* ChooseSpeciesView.swift in Sources */,
 				BCE48D2FCD0F20F23AEC0EF4 /* ChooseNationalityView.swift in Sources */,
-				BCE4817B0B89F5D95768925A /* CountryPickerView.swif.swift in Sources */,
+				BCE4817B0B89F5D95768925A /* CountryPickerView.swift in Sources */,
 				3093805F24460A2A00E23350 /* VesselRecordItemView.swift in Sources */,
 				BCE48D4A017A5B4B64690CCE /* ViolationPickerView.swift in Sources */,
 				BCE4854AADAFBC1B0BD9ECFB /* ChooseViolationsView.swift in Sources */,

--- a/o-fish-ios/Views/Components/Picker/Country/CountryPickerDataView.swift
+++ b/o-fish-ios/Views/Components/Picker/Country/CountryPickerDataView.swift
@@ -18,7 +18,7 @@ struct CountryPickerDataView: View {
 
     var body: some View {
         HStack(spacing: Dimensions.spacing) {
-            Text("\(flag(from: item.image).uppercased())")
+            Text("\(flag(for: item.code).uppercased())")
                 .font(.system(size: Dimensions.imageSize))
                 .foregroundColor(.white)
                 .clipShape(Circle())
@@ -34,10 +34,10 @@ struct CountryPickerDataView: View {
             .padding(.bottom, Dimensions.bottomPadding)
     }
 
-    private func flag(from country: String) -> String {
+    private func flag(for countryCode: String) -> String {
         let base: UInt32 = 127397 // magic number for transforming country prefix into emoji
         var emojiFlag = ""
-        for letter in country.uppercased().unicodeScalars {
+        for letter in countryCode.uppercased().unicodeScalars {
             if let element = UnicodeScalar(base + letter.value) {
                 emojiFlag.unicodeScalars.append(element)
             }
@@ -49,7 +49,7 @@ struct CountryPickerDataView: View {
 
 struct CountryPickerDataView_Previews: PreviewProvider {
     static var previews: some View {
-        CountryPickerDataView(item: CountryPickerData(image: "FR",
+        CountryPickerDataView(item: CountryPickerData(code: "FR",
                                                       title: "France"))
     }
 }

--- a/o-fish-ios/Views/Components/Picker/Country/CountryPickerView.swift
+++ b/o-fish-ios/Views/Components/Picker/Country/CountryPickerView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct CountryPickerData {
-    var image: String
+    var code: String
     var title: String
 }
 
 extension CountryPickerData: SearchableDataProtocol {
-    static let notSelected = CountryPickerData(image: "", title: "")
+    static let notSelected = CountryPickerData(code: "", title: "")
 
     var id: String {
         title
@@ -43,11 +43,11 @@ struct CountryPickerView: View {
 
 struct CountryPickerView_Previews: PreviewProvider {
     static var previews: some View {
-        let items = [CountryPickerData(image: "FR", title: "France"),
-                     CountryPickerData(image: "NL", title: "Netherlands"),
-                     CountryPickerData(image: "PL", title: "Poland")]
+        let items = [CountryPickerData(code: "FR", title: "France"),
+                     CountryPickerData(code: "NL", title: "Netherlands"),
+                     CountryPickerData(code: "PL", title: "Poland")]
 
-        return CountryPickerView(selectedItem: .constant(CountryPickerData(image: "FR",
+        return CountryPickerView(selectedItem: .constant(CountryPickerData(code: "FR",
                                                                            title: "France")),
                                  items: items,
                                  title: "Title" ,

--- a/o-fish-ios/Views/ReportDetails/VesselSummaryView.swift
+++ b/o-fish-ios/Views/ReportDetails/VesselSummaryView.swift
@@ -38,7 +38,7 @@ struct VesselSummaryView: View {
 
             HStack(alignment: .top, spacing: Dimensions.spacing) {
                 LabeledText(label: "Home Port", text: "\(vessel.homePort)")
-                LabeledText(label: "Flag State", text: "\(vessel.nationality)")
+                LabeledText(label: "Flag State", text: "\(getCountryName(from: vessel.nationality))")
             }
 
             if !vessel.attachments.notes.isEmpty || !vessel.attachments.photoIDs.isEmpty {
@@ -46,6 +46,10 @@ struct VesselSummaryView: View {
             }
         }
             .padding(.bottom, Dimensions.bottomPading)
+    }
+
+    private func getCountryName(from countryCode: String) -> String {
+        return Locale.autoupdatingCurrent.localizedString(forRegionCode: countryCode) ?? ""
     }
 }
 

--- a/o-fish-ios/Views/ReportFlow/ChooseScreens/ChooseNationalityView.swift
+++ b/o-fish-ios/Views/ReportFlow/ChooseScreens/ChooseNationalityView.swift
@@ -13,7 +13,7 @@ private class CountryHelper {
 
     private func pickerDataFromCountry(code: String) -> CountryPickerData? {
         if let name = Locale.autoupdatingCurrent.localizedString(forRegionCode: code) {
-            return CountryPickerData(image: code, title: name)
+            return CountryPickerData(code: code, title: name)
         }
         return nil
     }
@@ -70,7 +70,7 @@ struct ChooseNationalityView: View {
 
 struct ChooseNationalityView_Previews: PreviewProvider {
     static var previews: some View {
-        ChooseNationalityView(selectedItem: .constant(CountryPickerData(image: "FR",
+        ChooseNationalityView(selectedItem: .constant(CountryPickerData(code: "FR",
                                                                         title: "France")))
     }
 }

--- a/o-fish-ios/Views/ReportFlow/Vessel/VesselInformationInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/VesselInformationInputView.swift
@@ -88,7 +88,7 @@ struct VesselInformationInputView: View {
                         Binding<CountryPickerData>(
                             get: { self.displayedNationality },
                             set: {
-                                self.vessel.nationality = $0.title
+                                self.vessel.nationality = $0.code
                                 self.checkAllInput()
                         }
                     ))
@@ -116,17 +116,11 @@ struct VesselInformationInputView: View {
     }
 
     private var displayedNationality: CountryPickerData {
-        CountryPickerData(image: "\(transformCountryName(from: vessel.nationality))", title: vessel.nationality)
+        CountryPickerData(code: vessel.nationality, title: getCountryName(from: vessel.nationality))
     }
 
-    private func transformCountryName(from country: String) -> String {
-        for code in Locale.isoRegionCodes as [String] {
-            if let name = Locale.autoupdatingCurrent.localizedString(forRegionCode: code),
-                name == country {
-                return code
-            }
-        }
-        return ""
+    private func getCountryName(from countryCode: String) -> String {
+        return Locale.autoupdatingCurrent.localizedString(forRegionCode: countryCode) ?? ""
     }
 
     private func checkAllInput() {


### PR DESCRIPTION
Hey there! I am happy to contribute to your repository as part of Hacktoberfest 2020

This PR Closes #332 

Some rationale behind my changes:

• I renamed `image` variable to `code` in `CountryPickerData` because it is quite because previous name is quite ambiguous and misleading per se. So now variable `code` basically describes what kind of value it holds (short country code). `image` variable was used only once when magically retrieving country emoji, and even in that context it makes more sense to write function like `flag(for countryCode: String)`
• This change basically enabled me to retrieve `$0.code` directly and assign it to `vessel.nationality` in binding closure without introducing ambiguity (it'd be less obvious if it was `self.vessel.nationality = $0.image`, but it'd have worked the same way it does now).
• Also I fixed name of the `CountryPickerView.swift` file.