### PR TITLE
Change weight keyboard type to decimal pad and weightBinding to display a cleaned double value.

### DIFF
--- a/o-fish-ios/Helpers/Double+CleanValue.swift
+++ b/o-fish-ios/Helpers/Double+CleanValue.swift
@@ -1,0 +1,14 @@
+//
+//  Double+CleanValue.swift
+//  
+//  Created on 10/8/20.
+//  Copyright © 2020 WildAid. All rights reserved.
+//
+
+import Foundation
+
+extension Double {
+    var cleanValue: String {
+        return self.truncatingRemainder(dividingBy: 1) == 0 ? String(format: "%.0f", self) : String(self)
+    }
+}

--- a/o-fish-ios/Views/ReportFlow/Catch/CatchInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Catch/CatchInputView.swift
@@ -71,7 +71,7 @@ struct CatchInputView: View {
             HStack(spacing: Dimensions.offset) {
                 InputField(title: "Weight", text: weightBinding,
                            showingWarning: self.showingWeightWarning)
-                    .keyboardType(.numberPad)
+                    .keyboardType(.decimalPad)
 
                 ButtonField(title: "Unit",
                             text: NSLocalizedString(self.catchModel.unit.rawValue, comment: "Units localized"),
@@ -100,7 +100,7 @@ struct CatchInputView: View {
 
     private var weightBinding: Binding<String> {
         Binding<String>(
-            get: { self.catchModel.weight != 0 ? "\(self.catchModel.weight)" : "" },
+            get: { self.catchModel.weight != 0 ? self.catchModel.weight.cleanValue : "" },
             set: {
                 let numberFormatter = NumberFormatter()
                 numberFormatter.maximumFractionDigits = 2


### PR DESCRIPTION

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #319

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x ] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [ x] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x ] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



