### PR TITLE
Draft Boardings navigation bar show fix

### DIFF
--- a/o-fish-ios/Views/DraftBoardings/DraftBoardingsView.swift
+++ b/o-fish-ios/Views/DraftBoardings/DraftBoardingsView.swift
@@ -11,10 +11,21 @@ struct DraftBoardingsView: View {
 
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var settings: Settings
-    @State var rootIsActive: Bool = false
+    @State private var rootIsActive: Bool = false
     @State private var storedReports = [ReportViewModel]()
     @State private var state: States = .empty
-    @State private var showingDismissAlert = false
+
+    // (1/2) Binding workaround for view updating after appearing onscreen to show navigation bar
+    //
+    // Problem: after appering view on screen with slow-mode animation you could see jumped view to the top of screen.
+    // This way navigation bar is hidden
+    //
+    // It seems as Swift UI bug. Similar cases are described here:
+    // https://developer.apple.com/forums/thread/654471
+    // https://stackoverflow.com/questions/58756846/swiftui-view-content-layout-unexpectedly-pop-jumps-on-appear
+    // https://developer.apple.com/forums/thread/125800
+    @State private var updatedViewAfterShowing = false
+    // End of (1/2)
 
     private enum States {
         case loading, empty, loaded
@@ -31,7 +42,12 @@ struct DraftBoardingsView: View {
         }
         .navigationBarHidden(false)
         .onAppear(perform: loadReports)
-        .navigationBarTitle("Draft Boardings", displayMode: .inline)
+        // (2/2) Binding workaround for view updating after appearing onscreen to show navigation bar
+        .alert(isPresented: $updatedViewAfterShowing) {
+            Alert(title: Text(""))
+        }
+        // End of (2/2)
+        .navigationBarTitle(LocalizedStringKey("Draft Boardings"), displayMode: .inline)
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
             BackButton(label: "")


### PR DESCRIPTION
##  Related Issue

Fixes #331 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against a [local build](https://wildaid.github.io/build).

Optional items:
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 

 **Problem:** after appearing view on screen with slow-mode animation (video is attached below) you could see jumped view to the top of the screen. This way the navigation bar is hidden

 It seems like as Swift UI bug. Similar cases are described here:

- https://developer.apple.com/forums/thread/654471
- https://stackoverflow.com/questions/58756846/swiftui-view-content-layout-unexpectedly-pop-jumps-on-appear
- https://developer.apple.com/forums/thread/125800


* **Optional: Add any relevant screenshots here** 
Slow-mode video with animation bug: 
[view jump bug.mov.zip](https://github.com/WildAid/o-fish-ios/files/5360862/view.jump.bug.mov.zip)



