### PR TITLE
Partial Fix 360 Show Camera and Photos Picker

### DIFF
--- a/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
+++ b/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
@@ -175,10 +175,8 @@ struct ProfilePageView: View {
     }
 
     private func showPhotoTaker(source: UIImagePickerController.SourceType) {
-        guard let photo = profilePicture else {
-            print("Error, no placeholder image, so cannot edit picture")
-            return
-        }
+
+        let photo = self.profilePicture ?? PhotoViewModel()
 
         PhotoCaptureController.show(reportID: "", source: source, photoToEdit: photo) { controller, pictureId in
 


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #360 
Now shows picker for camera/photos properly and allows setting on Avatar.  On simulator, photo save still not working in Realm layer. 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 
May still be an issue with `realm.add(photo)` in PhotoViewModel.  Does not work on sim.

* **Optional: Add any relevant screenshots here** 



