### PR TITLE
Add @ObservedObject attachments to respond to attachment changes.

### DIFF
--- a/o-fish-ios.xcodeproj/project.pbxproj
+++ b/o-fish-ios.xcodeproj/project.pbxproj
@@ -193,8 +193,8 @@
 		49FDCD74241D274200C00574 /* PhotoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FDCD73241D274200C00574 /* PhotoViewModel.swift */; };
 		49FDCD8E241E200000C00574 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FDCD8D241E200000C00574 /* Photo.swift */; };
 		49FDCD90241E41EB00C00574 /* NoInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FDCD8F241E41EB00C00574 /* NoInputField.swift */; };
-		4D59CE7F252FF26500F02587 /* LocalConstants.swift in Resources */ = {isa = PBXBuildFile; fileRef = 4D59CE7E252FF26500F02587 /* LocalConstants.swift */; };
 		4D59CE87252FF38600F02587 /* Double+CleanValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D59CE86252FF38600F02587 /* Double+CleanValue.swift */; };
+		4D60F4102536073500AB7C45 /* LocalConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D60F40F2536073500AB7C45 /* LocalConstants.swift */; };
 		58803D1DF7134D26A62353B7 /* Pods_O_FISHTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D2A897480E19C63773305C9 /* Pods_O_FISHTests.framework */; };
 		A1404A98C1D9F0F6A7FFDF3F /* Pods_o_fish_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01F16184A0134571492EE1ED /* Pods_o_fish_ios.framework */; };
 		BCE48044A1B3C063E89649B4 /* CallToActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48AB83BB50A193A6B4113 /* CallToActionButton.swift */; };
@@ -492,8 +492,8 @@
 		49FDCD8D241E200000C00574 /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
 		49FDCD8F241E41EB00C00574 /* NoInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoInputField.swift; sourceTree = "<group>"; };
 		4D2A897480E19C63773305C9 /* Pods_O_FISHTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_O_FISHTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4D59CE7E252FF26500F02587 /* LocalConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalConstants.swift; sourceTree = "<group>"; };
 		4D59CE86252FF38600F02587 /* Double+CleanValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+CleanValue.swift"; sourceTree = "<group>"; };
+		4D60F40F2536073500AB7C45 /* LocalConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalConstants.swift; sourceTree = "<group>"; };
 		542E5D76C2521F4603E2BDEA /* Pods-o-fish-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-o-fish-ios.debug.xcconfig"; path = "Target Support Files/Pods-o-fish-ios/Pods-o-fish-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		75D1B2651469F1E66F32D4A7 /* Pods-O-FISHTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-O-FISHTests.debug.xcconfig"; path = "Target Support Files/Pods-O-FISHTests/Pods-O-FISHTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7F135385C428BA5F9EB62154 /* Pods-o-fish-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-o-fish-ios.release.xcconfig"; path = "Target Support Files/Pods-o-fish-ios/Pods-o-fish-ios.release.xcconfig"; sourceTree = "<group>"; };
@@ -812,6 +812,7 @@
 				490C0DB223F6B15A00283307 /* Info.plist */,
 				490C0DAC23F6B15A00283307 /* Preview Content */,
 				BCE489A0F819B698F681DB37 /* Design */,
+				4D60F40F2536073500AB7C45 /* LocalConstants.swift */,
 				49686CE125233D8F000C7F18 /* LocalConstants.swift */,
 			);
 			path = "o-fish-ios";
@@ -1111,7 +1112,6 @@
 		4D1939B72530F53E00B50B54 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				4D59CE7E252FF26500F02587 /* LocalConstants.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1432,7 +1432,6 @@
 				490C0DB123F6B15A00283307 /* LaunchScreen.storyboard in Resources */,
 				FBE107AE247FFF87001DA29C /* Localizable.strings in Resources */,
 				490C0DAE23F6B15A00283307 /* Preview Assets.xcassets in Resources */,
-				4D59CE7F252FF26500F02587 /* LocalConstants.swift in Resources */,
 				490C0DAB23F6B15A00283307 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1751,6 +1750,7 @@
 				BCE48D4A017A5B4B64690CCE /* ViolationPickerView.swift in Sources */,
 				BCE4854AADAFBC1B0BD9ECFB /* ChooseViolationsView.swift in Sources */,
 				BCE48602B111BBC1D7148B41 /* CountryPickerDataView.swift in Sources */,
+				4D60F4102536073500AB7C45 /* LocalConstants.swift in Sources */,
 				30E9393924A225C500011305 /* Double+LocationDegrees.swift in Sources */,
 				30CBCE4D24755663000AC61C /* ViolationStaticItemView.swift in Sources */,
 				BCE480EEF0B2F0E6A189ECC6 /* ViolationPickerDataView.swift in Sources */,
@@ -2039,7 +2039,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"o-fish-ios/Preview Content\"";
-				DEVELOPMENT_TEAM = PH747F3726;
+				DEVELOPMENT_TEAM = P3B9MPU7J2;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "o-fish-ios/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
@@ -2063,7 +2063,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"o-fish-ios/Preview Content\"";
-				DEVELOPMENT_TEAM = PH747F3726;
+				DEVELOPMENT_TEAM = P3B9MPU7J2;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "o-fish-ios/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.5;

--- a/o-fish-ios/Views/ReportFlow/Vessel/EMSInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Vessel/EMSInputView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EMSInputView: View {
     @ObservedObject var ems: EMSViewModel
+    @ObservedObject var attachments: AttachmentsViewModel
     @Binding var activeEditableComponentId: String
     @Binding var isEmsNonEmpty: Bool
     @Binding var informationComplete: Bool
@@ -43,6 +44,7 @@ struct EMSInputView: View {
         _informationComplete = informationComplete
         _showingWarningState = showingWarningState
 
+        self.attachments = ems.attachments
         self.reportId = reportId
         self.deleteClicked = deleteClicked
 
@@ -55,7 +57,7 @@ struct EMSInputView: View {
         VStack(spacing: Dimensions.spacing) {
             HStack {
                 TitleLabel(title: "Electronic Monitoring System")
-                AddAttachmentsButton(attachments: ems.attachments, reportId: reportId)
+                AddAttachmentsButton(attachments: attachments, reportId: reportId)
             }
                 .padding(.top, Dimensions.spacing)
 
@@ -73,8 +75,8 @@ struct EMSInputView: View {
 
             InputField(title: "Registry Number", text: registryNumberBinding, showingWarning: showingRegistryNumberWarning)
 
-            if !ems.attachments.photoIDs.isEmpty || !ems.attachments.notes.isEmpty {
-                AttachmentsView(attachments: ems.attachments)
+            if !attachments.isEmpty {
+                AttachmentsView(attachments: attachments)
             }
 
             SectionButton(title: "Remove EMS",


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #247 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 
Modifying attachments wasn't updating the correct view because the EMSInputView was not observing AttachmentsViewModel directly. There may be a better way to do this that I am unaware of.

Also note that there is a separate issue when attempting to delete a note. I'm going to create an issue for this.


* **Optional: Add any relevant screenshots here** 



