### PR TITLE
Incorrect header colors in dark mode

### DIFF
--- a/o-fish-ios/Views/DraftBoardings/DraftBoardingsView.swift
+++ b/o-fish-ios/Views/DraftBoardings/DraftBoardingsView.swift
@@ -25,18 +25,24 @@ struct DraftBoardingsView: View {
     }
 
     var body: some View {
-        VStack {
-            stateView()
-            Spacer()
-        }
-        .navigationBarHidden(false)
-        .onAppear(perform: loadReports)
-        .navigationBarTitle("Draft Boardings", displayMode: .inline)
-        .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
-            BackButton(label: "")
-        })
+        ZStack {
+            Color.oAltBackground
+                .edgesIgnoringSafeArea(.top)
 
+            VStack {
+                stateView()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .background(Color.oBackground)
+            .navigationBarHidden(false)
+            .onAppear(perform: loadReports)
+            .navigationBarTitle("Draft Boardings", displayMode: .inline)
+            .navigationBarBackButtonHidden(true)
+            .navigationBarItems(leading: Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
+                BackButton(label: "")
+            })
+        }
     }
 
     private func stateView() -> AnyView {

--- a/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
+++ b/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
@@ -33,93 +33,99 @@ struct ProfilePageView: View {
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: Dimensions.spacing) {
-            VStack(alignment: .leading) {
-                VStack(alignment: .leading, spacing: .zero) {
-                    HStack(spacing: Dimensions.stackSpacing) {
-                        PatrolBoatUserView(photo: profilePicture,
-                                           onSea: $dutyState.onDuty,
-                                           size: .large)
-                        VStack(alignment: .leading, spacing: .zero) {
-                            Text(user.name.fullName)
-                                .foregroundColor(.oFieldValue)
+        ZStack {
 
-                            Text(user.email)
-                                .foregroundColor(.oFieldTitle)
+            Color.oAltBackground
+                .ignoresSafeArea(edges: .top)
+
+            VStack(alignment: .center, spacing: Dimensions.spacing) {
+                VStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: .zero) {
+                        HStack(spacing: Dimensions.stackSpacing) {
+                            PatrolBoatUserView(photo: profilePicture,
+                                               onSea: $dutyState.onDuty,
+                                               size: .large)
+                            VStack(alignment: .leading, spacing: .zero) {
+                                Text(user.name.fullName)
+                                    .foregroundColor(.oFieldValue)
+
+                                Text(user.email)
+                                    .foregroundColor(.oFieldTitle)
+                            }
+                            .font(.body)
                         }
-                        .font(.body)
                     }
+                    .padding(.all, Dimensions.padding)
+                    Divider()
+                        .background(Color.oDivider)
+                        .frame(height: Dimensions.lineWidth)
+
+                    Toggle(isOn: dutyBinding) {
+                        Text(dutyState.onDuty ? "At Sea" : "Not At Sea")
+                            .foregroundColor(.oFieldTitle)
+                            .font(.callout)
+                    }
+                    .padding(.all, Dimensions.padding)
+
+                    Divider()
+                        .background(Color.oDivider)
+                        .frame(height: Dimensions.lineWidth)
+
+                    Toggle(isOn: $userSettings.forceDarkMode) {
+                        Text("Dark Mode")
+                            .foregroundColor(.oFieldTitle)
+                            .font(.callout)
+                    }
+                    .padding(.all, Dimensions.padding)
+
+                    Divider()
+                        .background(Color.oDivider)
+                        .frame(height: Dimensions.lineWidth)
                 }
-                .padding(.all, Dimensions.padding)
-                Divider()
-                    .background(Color.oDivider)
-                    .frame(height: Dimensions.lineWidth)
-
-                Toggle(isOn: dutyBinding) {
-                    Text(dutyState.onDuty ? "At Sea" : "Not At Sea")
-                        .foregroundColor(.oFieldTitle)
-                        .font(.callout)
+                .background(Color.oBackground)
+                VStack {
+                    Button(action: showLogoutAlert) {
+                        Spacer()
+                        Text("Log Out")
+                            .font(.body)
+                            .foregroundColor(.oAccent)
+                        Spacer()
+                    }
+                    .padding(.vertical, Dimensions.stackSpacing)
+                    .background(Color.clear)
+                    .cornerRadius(Dimensions.radius)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: .infinity)
+                            .stroke(Color.oAccent,
+                                    lineWidth: Dimensions.lineWidth)
+                    )
                 }
-                .padding(.all, Dimensions.padding)
+                .padding(.horizontal, Dimensions.padding)
+                Spacer()
 
-                Divider()
-                    .background(Color.oDivider)
-                    .frame(height: Dimensions.lineWidth)
-
-                Toggle(isOn: $userSettings.forceDarkMode) {
-                    Text("Dark Mode")
-                        .foregroundColor(.oFieldTitle)
-                        .font(.callout)
+                NavigationLink(destination:
+                                PatrolSummaryView(dutyReports: dutyReports,
+                                                  startDuty: startDuty,
+                                                  onDuty: dutyState,
+                                                  plannedOffDutyTime: plannedOffDutyTime,
+                                                  rootIsActive: .constant(false)),
+                               isActive: $showingPatrolSummaryView) {
+                    EmptyView()
                 }
-                .padding(.all, Dimensions.padding)
-
-                Divider()
-                    .background(Color.oDivider)
-                    .frame(height: Dimensions.lineWidth)
+                               .isDetailLink(false)
             }
             .background(Color.oBackground)
-            VStack {
-                Button(action: showLogoutAlert) {
-                    Spacer()
-                    Text("Log Out")
-                        .font(.body)
-                        .foregroundColor(.oAccent)
-                    Spacer()
-                }
-                .padding(.vertical, Dimensions.stackSpacing)
-                .background(Color.clear)
-                .cornerRadius(Dimensions.radius)
-                .overlay(
-                    RoundedRectangle(cornerRadius: .infinity)
-                        .stroke(Color.oAccent,
-                                lineWidth: Dimensions.lineWidth)
-                )
-            }
-            .padding(.horizontal, Dimensions.padding)
-            Spacer()
-
-            NavigationLink(destination:
-                            PatrolSummaryView(dutyReports: dutyReports,
-                                              startDuty: startDuty,
-                                              onDuty: dutyState,
-                                              plannedOffDutyTime: plannedOffDutyTime,
-                                              rootIsActive: .constant(false)),
-                           isActive: $showingPatrolSummaryView) {
-                EmptyView()
-            }
-            .isDetailLink(false)
+            .edgesIgnoringSafeArea(.bottom)
+            .navigationBarTitle("", displayMode: .inline)
+            .navigationBarBackButtonHidden(true)
+            .navigationBarItems(leading: Button(action: {
+                self.presentationMode.wrappedValue.dismiss()
+            }) {
+                Text("Close")
+                    .foregroundColor(.oAccent)
+            })
+            .showingAlert(alertItem: $showingAlertItem)
         }
-        .background(Color.oBackground)
-        .edgesIgnoringSafeArea(.bottom)
-        .navigationBarTitle("", displayMode: .inline)
-        .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: Button(action: {
-            self.presentationMode.wrappedValue.dismiss()
-        }) {
-            Text("Close")
-                .foregroundColor(.oAccent)
-        })
-        .showingAlert(alertItem: $showingAlertItem)
     }
 
     private var dutyBinding: Binding<Bool> {


### PR DESCRIPTION
Many screens have incorrect header colors.
How it was:
<img width="353" alt="Снимок экрана 2022-04-06 в 17 56 09" src="https://user-images.githubusercontent.com/52383559/162005461-6575a335-29f7-4d2c-8b6f-72475769ee53.png">
After fix:
<img width="350" alt="Снимок экрана 2022-04-06 в 18 00 44" src="https://user-images.githubusercontent.com/52383559/162005406-e65599a6-8d71-4d16-8fe2-3591db4ffe45.png">

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
