### PR TITLE
Fix unit picker 

### DIFF
--- a/o-fish-ios.xcodeproj/project.pbxproj
+++ b/o-fish-ios.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		BCE48F10100DC3B1E448EFA5 /* CrewMemberShortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48456167E25D77C838694 /* CrewMemberShortView.swift */; };
 		BCE48F5083615CEB327EF9BD /* PhotoQueryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE489E93BCA8E7B291D6830 /* PhotoQueryManager.swift */; };
 		BCE48F9EA32E0A9B405E6F04 /* SectionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE48AB036DA398FBFF3E3B4 /* SectionButton.swift */; };
+		F24C7E1627FAF67D00AA6504 /* UnitPickerField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24C7E1527FAF67D00AA6504 /* UnitPickerField.swift */; };
 		F2ADF94227E9BFE2003D1245 /* DatePickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2ADF94127E9BFE2003D1245 /* DatePickerController.swift */; };
 		FBE107AE247FFF87001DA29C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = FBE107B0247FFF87001DA29C /* Localizable.strings */; };
 /* End PBXBuildFile section */
@@ -596,6 +597,7 @@
 		BCE48FCB06AC5B25AF1BCA74 /* CatchOnBoardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatchOnBoardView.swift; sourceTree = "<group>"; };
 		BCE48FD1BBBF69F49C6EC765 /* NavigationBarViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarViewModifier.swift; sourceTree = "<group>"; };
 		BCE48FFF9C49070CE13E7B27 /* PatrolBoatUserView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatrolBoatUserView.swift; sourceTree = "<group>"; };
+		F24C7E1527FAF67D00AA6504 /* UnitPickerField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitPickerField.swift; sourceTree = "<group>"; };
 		F2ADF94127E9BFE2003D1245 /* DatePickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerController.swift; sourceTree = "<group>"; };
 		FBC9242D2481198900A7C005 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		FBC9242E2481198900A7C005 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 				BCE484E6974BBB4F08413A3E /* InputField.swift */,
 				BCE481F6902A242DA2208F95 /* CaptionLabel.swift */,
 				BCE489430E879F75C5AAF84F /* ButtonField.swift */,
+				F24C7E1527FAF67D00AA6504 /* UnitPickerField.swift */,
 				BCE481CB48F61489E76F8F47 /* DatePickerWithButton.swift */,
 				BCE4887849269C5010940019 /* TitleLabel.swift */,
 				BCE489BFAF7761711B175260 /* WrappedShadowView.swift */,
@@ -1842,6 +1845,7 @@
 				30E315CF2507AB830037235E /* BottomPatrolView.swift in Sources */,
 				BCE48D3B49087F1687BB71D2 /* ScrollableTabBarItemView.swift in Sources */,
 				BCE48ECFBCDE115D3867DAC4 /* AlertItem.swift in Sources */,
+				F24C7E1627FAF67D00AA6504 /* UnitPickerField.swift in Sources */,
 				49B83EE32489546D00027B8C /* Offence.swift in Sources */,
 				BCE48D2E80CF82657D03614D /* ExclamationIconView.swift in Sources */,
 				BCE4814543022D42A642CA4A /* KeyboardController.swift in Sources */,

--- a/o-fish-ios/Views/Components/UnitPickerField.swift
+++ b/o-fish-ios/Views/Components/UnitPickerField.swift
@@ -1,0 +1,51 @@
+//
+//  PickerField.swift
+//  
+//  Created on 04.04.2022.
+//  Copyright © 2022 WildAid. All rights reserved.
+//
+
+import SwiftUI
+
+struct UnitPickerField: View {
+    let title: String
+    var options: [CatchViewModel.UnitSpecification]
+    @Binding var unit: CatchViewModel.UnitSpecification
+
+    var showingWarning = false
+
+    var captionColor = Color.removeAction
+    var separatorColor = Color.inactiveBar
+    var warningColor = Color.spanishOrange
+
+    private enum Dimensions {
+        static let noSpacing: CGFloat = 0
+        static let bottomPadding: CGFloat = 16
+        static let textMinHeight: CGFloat = 21.5
+    }
+
+    var body: some View {
+        VStack(spacing: Dimensions.noSpacing) {
+            CaptionLabel(title: title, color: showingWarning ? warningColor : captionColor)
+
+            Picker("", selection: $unit) {
+                ForEach(0..<options.count) { index in
+                    TextLabel(title: options[index].rawValue, color: .oText)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+        Divider()
+            .background(showingWarning ? warningColor : separatorColor)
+
+        }
+    }
+}
+
+struct PickerField_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyView()
+    }
+}

--- a/o-fish-ios/Views/ReportFlow/Catch/CatchInputView.swift
+++ b/o-fish-ios/Views/ReportFlow/Catch/CatchInputView.swift
@@ -15,6 +15,7 @@ struct CatchInputView: View {
     private let reportId: String
     private let index: Int
     private var removeClicked: ((CatchViewModel) -> Void)?
+    private var options = CatchViewModel.UnitSpecification.allCases
     @Binding private var showingSpeciesWarning: Bool
     @Binding private var showingWeightWarning: Bool
     @Binding private var showingUnitWarning: Bool
@@ -66,11 +67,10 @@ struct CatchInputView: View {
                            tag: 0,
                            showingWarning: self.showingWeightWarning,
                            keyboardType: .decimalPad)
-                ButtonField(title: "Unit",
-                            text: NSLocalizedString(self.catchModel.unit.rawValue,
-                            comment: "Units localized"),
-                            showingWarning: self.showingUnitWarning,
-                            fieldButtonClicked: self.showUnitPickerClicked)
+                UnitPickerField(title: "Unit",
+                                options: options,
+                                unit: $catchModel.unit,
+                                showingWarning: self.showingUnitWarning)
             }
             InputField(title: "Count",
                        text: countBinding,
@@ -118,22 +118,6 @@ struct CatchInputView: View {
     private var buttonTitle: String {
         catchModel.fish.isEmpty ? (NSLocalizedString("Catch", comment: "") + " \(self.index)")
                                 : NSLocalizedString(catchModel.fish, comment: "Fish type")
-    }
-
-    private func showUnitPickerClicked() {
-        // TODO: for some reason this works only from action and not from viewModifier
-        // TODO: review when viewModifier actions will be available
-
-        let popoverId = UUID().uuidString
-        let unitPickerSelectClicked = { (unit: UnitPickerWithButton.UnitSpecification) in
-            self.catchModel.unit = unit
-            self.checkAllInput()
-            PopoverManager.shared.hidePopover(id: popoverId)
-        }
-        PopoverManager.shared.showPopover(id: popoverId) {
-            UnitPickerWithButton(selectButtonClicked: unitPickerSelectClicked)
-                .background(Color.white)
-        }
     }
 
     private func checkAllInput() {


### PR DESCRIPTION

Unit picker was broken in iOS 15. 
<img src="https://user-images.githubusercontent.com/52383559/162001540-b9535b18-71c4-484f-8677-efe08845f0e6.png" height=400/>

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
