### PR TITLE
Save a draft report every time the user navigates to another panel #301

### DIFF
--- a/o-fish-ios/Views/ReportFlow/ReportNavigationRootView.swift
+++ b/o-fish-ios/Views/ReportFlow/ReportNavigationRootView.swift
@@ -133,8 +133,8 @@ struct ReportNavigationRootView: View {
 
     private func saveAlertClicked() {
         if self.isSaveAvailable() {
-        report.draft = true
-        self.save()
+            report.draft = true
+            self.save()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self.showSubmittedAlert(isDraft: true)
             }

--- a/o-fish-ios/Views/ReportFlow/TopTabBarContainerView.swift
+++ b/o-fish-ios/Views/ReportFlow/TopTabBarContainerView.swift
@@ -41,7 +41,11 @@ struct TopTabBarContainerView: View {
     @Binding private var notFilledScreens: [String]
 
     @State private var tabBarItems: [TabBarItem]
-    @State private var selectedItem: TabBarItem
+    @State private var selectedItem: TabBarItem {
+        didSet {
+            updateDraftReport()
+        }
+    }
 
     @State private var mainButtonTitle: String
     @State private var showingNotCompleteState: Bool
@@ -345,6 +349,15 @@ struct TopTabBarContainerView: View {
                                           message: itemsToSkip.map { NSLocalizedString($0, comment: "") }.joined(separator: "\n"),
                                           primaryButton: .cancel(Text("Skip"), action: skipClicked)
         )
+    }
+
+    private func updateDraftReport() {
+        if let realm = app.currentUser()?.agencyRealm() {
+            self.report.draft = true
+            self.report.save(realm)
+        } else {
+            print("Realm not available")
+        }
     }
 }
 


### PR DESCRIPTION
## Related Issue https://github.com/WildAid/o-fish-ios/issues/301
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->


## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
