### PR TITLE
Cleanup: don't use hardcoded text and colors #374

### DIFF
--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/actionBlue.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/actionBlue.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.480",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/appGray.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/appGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "0.730",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/backgroundGrey.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/backgroundGrey.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/blackWithOpacity.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/blackWithOpacity.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/bubbles.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/bubbles.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xEF",
+          "red" : "0xDE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/captainGray.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/captainGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xD8",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/crusoe.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/crusoe.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x28",
+          "green" : "0x61",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/darkRed.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/darkRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0B",
+          "green" : "0x0B",
+          "red" : "0x96"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/darkSpringGreen.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/darkSpringGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x37",
+          "green" : "0x85",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/faluRed.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/faluRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x15",
+          "green" : "0x15",
+          "red" : "0x89"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/iconGreen.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/iconGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.290",
+          "green" : "0.700",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/iconsGray.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/iconsGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDD",
+          "green" : "0xDD",
+          "red" : "0xDD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lightGrayButton.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lightGrayButton.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.160",
+          "blue" : "161",
+          "green" : "161",
+          "red" : "161"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lightGrayIcon.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lightGrayIcon.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCB",
+          "green" : "0xCB",
+          "red" : "0xCB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lightSpringGreen.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lightSpringGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0xD2",
+          "red" : "0x53"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lilyWhite.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/lilyWhite.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEF",
+          "green" : "0xF4",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/main.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/main.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "116",
+          "green" : "64",
+          "red" : "10"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/moonLightYellow.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/moonLightYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x75",
+          "green" : "0xD5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/moonYellow.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/moonYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x22",
+          "green" : "0xBF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/oasis.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/oasis.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xEC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/persianLightRed.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/persianLightRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x66",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/persianRed.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/persianRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x22",
+          "green" : "0x22",
+          "red" : "0xCF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/removeAction.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/removeAction.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x97",
+          "green" : "0x97",
+          "red" : "0x97"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/rowAmber.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/rowAmber.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x45",
+          "red" : "0x61"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/spanishOrange.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/spanishOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x70",
+          "red" : "0xE1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Assets.xcassets/SingleAppearanceColors/vanillaIce.colorset/Contents.json
+++ b/o-fish-ios/Assets.xcassets/SingleAppearanceColors/vanillaIce.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD4",
+          "green" : "0xD4",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/o-fish-ios/Design/Color+Design.swift
+++ b/o-fish-ios/Design/Color+Design.swift
@@ -15,9 +15,6 @@ extension UIColor {
             blue: CGFloat(blue) / 255.0,
             alpha: alpha)
     }
-
-    public static let main = UIColor(red: 10, green: 64, blue: 116) // #0a4074
-    public static let actionBlue = UIColor(red: 0, green: 0.48, blue: 1, alpha: 1.0)
 }
 
 extension Color {
@@ -27,47 +24,4 @@ extension Color {
                 blue: Double(blue) / 255.0,
                 opacity: alpha)
     }
-}
-
-extension Color {
-    public static let main = Color(.main)
-
-    public static let backgroundGrey = Color(red: 249, green: 250, blue: 250) // f9fafa
-    public static let text = Color.oBackground
-
-    public static let callToAction = main
-
-    // gray
-    public static let iconsGray = Color(white: 221.0/255.0) // #DDDDDD
-    public static let captainGray = Color(white: 216.0/255.0)// #D8D8D8
-    public static let removeAction = Color(white: 151.0/255.0)// #979797
-    public static let inactiveBar = Color("oInactiveBar")// #E6E6E6
-    public static let oSearchBar = Color("oSearchBar")// #EEEEEF
-
-    public static let lilyWhite = Color(red: 236, green: 244, blue: 239) // #ECF4EF
-    public static let darkSpringGreen = Color(red: 0, green: 133, blue: 55) // #008537
-    public static let lightSpringGreen = Color(red: 83, green: 210, blue: 136) // #53D288
-    public static let moonYellow = Color(red: 255, green: 191, blue: 34) //#FFBF22
-    public static let moonLightYellow = Color(red: 255, green: 213, blue: 117) //#FFD575
-    public static let oasis = Color(red: 255, green: 236, blue: 188) // ffecbc
-    public static let spanishOrange = Color(red: 255, green: 112, blue: 0) // #E17000
-    public static let persianRed = Color(red: 207, green: 34, blue: 34) //#CF2222
-    public static let persianLightRed = Color(red: 255, green: 102, blue: 120) //#FF6666
-    public static let vanillaIce = Color(red: 246, green: 212, blue: 212) // #F6D4D4
-    public static let darkRed = Color(red: 150, green: 11, blue: 11) //#960B0B
-    public static let bubbles = Color(red: 222, green: 239, blue: 229) //#DEEFE5
-    public static let crusoe = Color(red: 0, green: 97, blue: 40)//#006128
-    public static let rowAmber = Color(red: 97, green: 69, blue: 0) //#614500
-    public static let faluRed = Color(red: 137, green: 21, blue: 21) //#891515
-
-    public static let appGray = Color(white: 186.0/255.0)
-
-    public static let lightGrayButton = Color(red: 161, green: 161, blue: 161, alpha: 0.16)
-
-    public static let blackWithOpacity = Color(red: 0, green: 0, blue: 0, alpha: 0.3)
-
-    public static let lightGrayIcon = Color(red: 203, green: 203, blue: 203) //#CBCBCB
-    public static let iconGreen = Color(red: 0, green: 0.7, blue: 0.29)
-    public static let actionBlue = Color(red: 0, green: 0.48, blue: 1)
-
 }

--- a/o-fish-ios/Helpers/Color+Theme.swift
+++ b/o-fish-ios/Helpers/Color+Theme.swift
@@ -50,6 +50,14 @@ extension UIColor {
     }
 
     // MARK: - Named Colors
+    public static var main: UIColor {
+        return UIColor(named: "main")!
+    }
+
+    public static var actionBlue: UIColor {
+        return UIColor(named: "actionBlue")!
+    }
+
     public static var oBlue: UIColor {
         return UIColor(named: "oBlue")!
     }
@@ -74,11 +82,23 @@ extension UIColor {
     public static var oText: UIColor {
         return UIColor(named: "oText")!
     }
+
+    public static var inactiveBar: UIColor {
+        return UIColor(named: "oInactiveBar")!
+    }
+
+    public static var oSearchBar: UIColor {
+        return UIColor(named: "oSearchBar")!
+    }
 }
 
 extension Color {
 
     // MARK: - Named Colors
+    public static var main: Color {
+        return Color("main")
+    }
+
     public static var oAmber: Color {
         return Color("oAmber")
     }
@@ -154,5 +174,114 @@ extension Color {
 
     public static var oText: Color {
         return Color("oText")
+    }
+
+    public static var inactiveBar: Color {
+        return Color("oInactiveBar")
+    }
+
+    public static var oSearchBar: Color {
+        return Color("oSearchBar")
+    }
+
+    // MARK: - Single appearance colors
+    public static var backgroundGrey: Color {
+        return Color("backgroundGrey")
+    }
+
+    public static var iconsGray: Color {
+        return Color("iconsGray")
+    }
+
+    public static var captainGray: Color {
+        return Color("captainGray")
+    }
+
+    public static var removeAction: Color {
+        return Color("removeAction")
+    }
+
+    public static var lilyWhite: Color {
+        return Color("lilyWhite")
+    }
+
+    public static var darkSpringGreen: Color {
+        return Color("darkSpringGreen")
+    }
+
+    public static var lightSpringGreen: Color {
+        return Color("lightSpringGreen")
+    }
+
+    public static var moonYellow: Color {
+        return Color("moonYellow")
+    }
+
+    public static var moonLightYellow: Color {
+        return Color("moonLightYellow")
+    }
+
+    public static var oasis: Color {
+        return Color("oasis")
+    }
+
+    public static var spanishOrange: Color {
+        return Color("spanishOrange")
+    }
+
+    public static var persianRed: Color {
+        return Color("persianRed")
+    }
+
+    public static var persianLightRed: Color {
+        return Color("persianLightRed")
+    }
+
+    public static var vanillaIce: Color {
+        return Color("vanillaIce")
+    }
+
+    public static var darkRed: Color {
+        return Color("darkRed")
+    }
+
+    public static var bubbles: Color {
+        return Color("bubbles")
+    }
+
+    public static var crusoe: Color {
+        return Color("crusoe")
+    }
+
+    public static var rowAmber: Color {
+        return Color("rowAmber")
+    }
+
+    public static var faluRed: Color {
+        return Color("faluRed")
+    }
+
+    public static var appGray: Color {
+        return Color("appGray")
+    }
+
+    public static var lightGrayButton: Color {
+        return Color("lightGrayButton")
+    }
+
+    public static var blackWithOpacity: Color {
+        return Color("blackWithOpacity")
+    }
+
+    public static var lightGrayIcon: Color {
+        return Color("lightGrayIcon")
+    }
+
+    public static var iconGreen: Color {
+        return Color("iconGreen")
+    }
+
+    public static var actionBlue: Color {
+        return Color("actionBlue")
     }
 }

--- a/o-fish-ios/Views/Components/RectangleButton.swift
+++ b/o-fish-ios/Views/Components/RectangleButton.swift
@@ -11,7 +11,7 @@ struct RectangleButton: View {
     var title: String
     var action: (() -> Void)?
 
-    var backgroundColor = Color.callToAction
+    var backgroundColor = Color.main
     var foregroundColor = Color.white
 
     var spacing: CGFloat = 16


### PR DESCRIPTION
## Related Issue https://github.com/WildAid/o-fish-ios/issues/374
All colors have been moved to assets. Unused colors have been removed.


## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
