### PR TITLE
Log out + Not at Sea

### DIFF
--- a/Localization/es-419.lproj/Localizable.strings
+++ b/Localization/es-419.lproj/Localizable.strings
@@ -160,7 +160,7 @@
 "Draft Boarding" = "Draft Boarding";
 "Close" = "Close";
 "Log Out?" = "Log Out?";
-"All draft boardings will be deleted!" = "All draft boardings will be deleted!";
+"All draft boardings will be deleted!" = "All draft boardings will be deleted, and you will be marked 'Not at Sea'!";
 "Edit" = "Edit";
 "0 Draft Boardings" = "0 Draft Boardings";
 "Save and Finish Later" = "Save and Finish Later";

--- a/Localization/fr.lproj/Localizable.strings
+++ b/Localization/fr.lproj/Localizable.strings
@@ -160,7 +160,7 @@
 "Draft Boarding" = "Draft Boarding";
 "Close" = "Close";
 "Log Out?" = "Log Out?";
-"All draft boardings will be deleted!" = "All draft boardings will be deleted!";
+"All draft boardings will be deleted!" = "All draft boardings will be deleted, and you will be marked 'Not at Sea'!";
 "Edit" = "Edit";
 "0 Draft Boardings" = "0 Draft Boardings";
 "Save and Finish Later" = "Save and Finish Later";

--- a/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
+++ b/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
@@ -157,6 +157,7 @@ struct ProfilePageView: View {
             return
         }
 
+        saveOnDutySession()
         deleteDraftReports()
 
         user.logOut { _ in
@@ -165,6 +166,11 @@ struct ProfilePageView: View {
             }
             NotificationManager.shared.removeAllNotification()
         }
+    }
+
+    private func saveOnDutySession() {
+        startDuty.save(existingObject: true)
+        dutyState.recordOnDutyChange(status: false, date: plannedOffDutyTime)
     }
 
     private func deleteDraftReports() {

--- a/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
+++ b/o-fish-ios/Views/PatrolBoat/ProfilePageView.swift
@@ -146,7 +146,7 @@ struct ProfilePageView: View {
 
     private func showLogoutAlert() {
         showingAlertItem = AlertItem(title: "Logout?",
-                                     message: "All draft boardings will be deleted!",
+                                     message: "All draft boardings will be deleted, and you will be marked 'Not at Sea'!",
                                      primaryButton: .destructive(Text("Log Out"), action: logoutAlertClicked),
                                      secondaryButton: .cancel())
     }


### PR DESCRIPTION
## Related Issue https://github.com/WildAid/o-fish-ios/issues/407
Session saved and user status changed to "not at sea" after logging out.

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
