### PR TITLE
Captain and Crew remove extra click

### DIFF
--- a/o-fish-ios/Views/ReportFlow/Crew/CrewMemberView.swift
+++ b/o-fish-ios/Views/ReportFlow/Crew/CrewMemberView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct CrewMemberView: View {
-    @Binding var currentEditingCrewMemberId: String
     @Binding var isCrewMemberNonEmpty: Bool
     @Binding var informationComplete: Bool
     @Binding var showingWarningState: Bool
@@ -23,21 +22,14 @@ struct CrewMemberView: View {
 
     var body: some View {
         wrappedShadowView {
-            if crewMember.id == currentEditingCrewMemberId {
-                CrewMemberInputView(isCrewMemberNonEmpty: self.$isCrewMemberNonEmpty,
-                    informationComplete: $informationComplete,
-                    showingWarningState: $showingWarningState,
-                    crewMember: crewMember,
-                    reportId: reportId,
-                    index: index,
-                    isCaptain: crewMember.isCaptain,
-                    removeClicked: removeClicked)
-            } else {
-                CrewMemberStaticView(crewMember: crewMember,
-                    index: index,
-                    isCaptain: crewMember.isCaptain,
-                    editClicked: editClicked)
-            }
+            CrewMemberInputView(isCrewMemberNonEmpty: self.$isCrewMemberNonEmpty,
+                informationComplete: $informationComplete,
+                showingWarningState: $showingWarningState,
+                crewMember: crewMember,
+                reportId: reportId,
+                index: index,
+                isCaptain: crewMember.isCaptain,
+                removeClicked: removeClicked)
         }
     }
 }
@@ -47,7 +39,7 @@ struct CrewMemberView_Previews: PreviewProvider {
 
     static var previews: some View {
         VStack {
-            CrewMemberView(currentEditingCrewMemberId: .constant("1"),
+            CrewMemberView(
                 isCrewMemberNonEmpty: .constant(false),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false),
@@ -55,7 +47,7 @@ struct CrewMemberView_Previews: PreviewProvider {
                 reportId: "TestId",
                 index: 1
             )
-            CrewMemberView(currentEditingCrewMemberId: .constant(crewMember.id),
+            CrewMemberView(
                 isCrewMemberNonEmpty: .constant(false),
                 informationComplete: .constant(false),
                 showingWarningState: .constant(false),

--- a/o-fish-ios/Views/ReportFlow/Crew/CrewView.swift
+++ b/o-fish-ios/Views/ReportFlow/Crew/CrewView.swift
@@ -17,8 +17,6 @@ struct CrewView: View {
     @State private var crewMemberWaitingRemoveConfirmation: CrewMemberViewModel?
     @State private var initialCaptain = CrewMemberViewModel()
     @State private var initialCrew = [CrewMemberViewModel]()
-
-    @State private var currentEditingCrewMemberId: String
     @State private var isCurrentEditingCrewNonEmpty: Bool
 
     @State private var crewMembersComplete: [String: Bool]
@@ -37,9 +35,6 @@ struct CrewView: View {
         self.report = report
 
         _showingPrefilledAlert = prefilledCrewAvailable
-        _currentEditingCrewMemberId = report.crew.filter({ $0.isEmpty }).count != 0 ?
-            State(initialValue: report.crew.filter({ $0.isEmpty }).first?.id ?? "") :
-            State(initialValue: report.captain.id)
         _isCurrentEditingCrewNonEmpty = State(initialValue: !report.captain.isEmpty)
         self._showingAlertItem = showingAlertItem
         _allFieldsComplete = allFieldsComplete
@@ -51,7 +46,7 @@ struct CrewView: View {
         KeyboardControllingScrollView {
             VStack(spacing: Dimensions.spacing) {
                 ForEach(self.allCrew.enumeratedArray(), id: \.element.id) { (index, member) in
-                    CrewMemberView(currentEditingCrewMemberId: self.$currentEditingCrewMemberId,
+                    CrewMemberView(
                         isCrewMemberNonEmpty: self.$isCurrentEditingCrewNonEmpty,
                         informationComplete: self.informationCompleteBinding(member),
                         showingWarningState: self.$showingWarningState,
@@ -65,7 +60,7 @@ struct CrewView: View {
 
                 if !(self.report.crew.last?.isEmpty ?? true)
                        || self.report.crew.isEmpty
-                       || (self.isCurrentEditingCrewNonEmpty && self.report.crew.last?.id == self.currentEditingCrewMemberId) {
+                       || (self.isCurrentEditingCrewNonEmpty) {
 
                     SectionButton(title: "Add Crew Member", systemImageName: "plus") {
                         self.addCrewMemberClicked()
@@ -115,7 +110,6 @@ struct CrewView: View {
             let emptyCaptain = CrewMemberViewModel()
             emptyCaptain.isCaptain = true
             report.captain = emptyCaptain
-            currentEditingCrewMemberId = report.captain.id
             report.crew = [CrewMemberViewModel]()
             if showingAlertItem == nil {
                 showingAlertItem = AlertItem(
@@ -190,7 +184,6 @@ struct CrewView: View {
     private func prefillCrewClicked() {
         report.captain = initialCaptain
         report.crew = initialCrew
-        currentEditingCrewMemberId = report.crew.last?.id ?? ""
         checkingForComplete()
         checkAllInput()
         showingPrefilledAlert = false
@@ -203,7 +196,6 @@ struct CrewView: View {
     }
 
     private func updateCurrentCrewMemberStatus(_ crewMember: CrewMemberViewModel?) {
-        currentEditingCrewMemberId = crewMember?.id ?? ""
         isCurrentEditingCrewNonEmpty = !(crewMember?.isEmpty ?? true)
         checkAllInput()
     }


### PR DESCRIPTION
## Related Issue https://github.com/WildAid/o-fish-ios/issues/412
Removed the ability to edit for crew view

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).